### PR TITLE
Fix cursor style for 'choose' links

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@ END:VEVENT
       <strong><%= item.name %></strong>.
       <em><%= item.location %></em>.
       <%= item.info %>
-      <a class="choose">(choose)</a>
+      <a class="choose" href>(choose)</a>
     </p>
   </div>
 </script>


### PR DESCRIPTION
The cursor style didn't change to 'pointer' when hovering over
'choose' links to select a tutorial group. This was due to the a tag
not having a href attribute.