### PR TITLE
'Pre-choose' events with no alternative available times. Refactor-corrected spelling of 'compulsory' through all source code.

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,8 +89,8 @@ TRANSP:OPAQUE
 END:VEVENT
 </script>
 
-<script type="text/template" id="compulsary-event-template">
-  <div class='lesson' data-eventtype='compulsary'
+<script type="text/template" id="compulsory-event-template">
+  <div class='lesson' data-eventtype='compulsory'
        data-name='<%= item.name %>'>
     <span class="glyphicon glyphicon-pushpin"></span>
     <strong><%= item.name %></strong>.

--- a/js/timetable.js
+++ b/js/timetable.js
@@ -16,7 +16,7 @@ var Calendar = {
         this.weekdays                 = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
         this.weekdaysFull             = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
         this.template                 = _.template($("#calendar-template").text());
-        this.compulsaryLessonTemplate = $("#compulsary-event-template").text();
+        this.compulsoryLessonTemplate = $("#compulsory-event-template").text();
         this.groupLessonTemplate      = $("#group-event-template").text();
         this.html                     = this.template(this.tradingHours);
         this.courseGrids              = [];
@@ -89,16 +89,19 @@ var Calendar = {
         }
 
     },
-    putCompulsaryItem : function (item) {
-        var displayDiv = $(_.template(Calendar.compulsaryLessonTemplate, {item: item}));
+    putCompulsoryItem : function (item) {
+        var displayDiv = $(_.template(Calendar.compulsoryLessonTemplate, {item: item}));
         Calendar.putItem(item, displayDiv);
     },
     putGroupItem      : function (item) {
+		
         var displayDiv = $(_.template(Calendar.groupLessonTemplate, {item: item}));
-
+		
         $(displayDiv.find('a.choose')[0]).on('click', function (event) {
             event.preventDefault();
 
+			//Cycles through every item on the timetable and compares it to the one which has been 'chosen'
+			//and appropriately removes identical items. Hides the 'choose' button on the 'chosen' one.
             Course.tutorials[displayDiv.data('group')] = displayDiv.data('id');
             _($(".lesson")).each(function (item) {
                 var $item = $(item);
@@ -116,8 +119,13 @@ var Calendar = {
         });
 
         Calendar.putItem(item, displayDiv);
+		
+		if (item.solo) { //If the class has no alternatives, automatically 'choose' it
+			$(displayDiv.find('a.choose')[0]).click();
+		}
     },
     putLessonGroup    : function (group) {
+
         if (group[0] === 'group') {
             for (var i = group[1].length - 1; i >= 0; i--) {
                 var key = group[1][i].name + filterNumbers(group[1][i].info);
@@ -125,11 +133,14 @@ var Calendar = {
                 // Build tutorial object if is not in recovering mode
                 if (!Course.tutorials[key]) Course.tutorials[key] = 0;
 
+				
+				
                 if (!Course.tutorials[key] || Course.tutorials[key] == group[1][i].id)
-                    Calendar.putGroupItem(group[1][i]);
+					Calendar.putGroupItem(group[1][i]);
+				
             }
         } else {
-            Calendar.putCompulsaryItem(group[1]);
+            Calendar.putCompulsoryItem(group[1]);
         }
     },
     columnMerge       : function () {
@@ -354,6 +365,37 @@ var Course = {
             }, 2000);
         } else {
             $("#add-course").html('Add');
+			
+			//Count the number of alternatives to each class. If there are none, mark it with .solo=true so it can be pre-chosen
+			var classAlternatives = []; //info as key, num alternatives as return
+			var classTypes = []; //info as key, id as return
+			var classEnum = []; //id as key, info as return
+			
+			_(data).each(
+				function (group) {
+					if (group[0] === 'group') {
+						var info = filterNumbers(group[1][0].info);
+						
+						if (classTypes[info] == undefined) {
+							classTypes[info] = classEnum.length;
+							classEnum[classEnum.length] = info;
+						}
+						if (classAlternatives[info] == undefined) classAlternatives[info] = 0;
+						classAlternatives[info]++;
+					}
+				}
+			);
+			
+			_(data).each(
+				function (group) {
+					if (group[0] === 'group') {
+						var info = filterNumbers(group[1][0].info);
+						if (classAlternatives[info]==1) group[1][0].solo = true;
+						else group[1][0].solo = false;
+					}
+				}
+			);
+			
             _(data).each(Calendar.putLessonGroup);
             Course.courses.push(courseName);
 

--- a/js/timetable_analyser.js
+++ b/js/timetable_analyser.js
@@ -51,7 +51,7 @@ var partitionLessons = function (lessons) {
         if (partition.hasOwnProperty(key)) {
             if (isCompulsory(key)) {
                 for (var member in partition[key]) {
-                    out.push(["compulsary", partition[key][member]]);
+                    out.push(["compulsory", partition[key][member]]);
                 }
             } else {
                 out.push(["group", partition[key]]);


### PR DESCRIPTION
Corrected spelling of 'compulsory' in all files.

Events which have no alternatives on the timetable (eg. unique lectures)
will be 'pre-chosen.' That is, users don't need to press "choose" on the
event as this will be done for them if there are no other alternative
timeslots for the same item.

This is implemented by adding a .solo tag to each item, which is set to
true if it is the only event of its type in the course. Its choose tag
is then artificially clicked after adding it to the calendar.

(Note: I am unsure what all of the 'compulsory' things throughout the
code are actually meant to refer to or whether they were meant to refer
to classes with no alternative as I addressed in my other changes. Or is
it that some courses have optional events as well as a range of
alternative compulsory ones? It didn't seem to apply to anything in any
of my courses, or I grossly misunderstood it. I'm new to the uni and a
pleb.)