### PR TITLE
Full screen dismissable dialog advertising the new timetable.cssa.club site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 * Timetable database last update: 2021-10-31
 
-## Modifacation Note
+## :warning: This project is no longer maintained. It has been replaced by [anucssa/anutimetable](https://github.com/anucssa/anutimetable), available at https://timetable.cssa.club/ :warning:
+
+## Modification Notes
 
 Any changes to [index.html](index.html), [js/timetable.js](js/timetable.js) and [anuscrape/scraper.py](anuscrape/scraper.py) should be synchronized with the template files in [semester_update](/semester_update) folder.
 

--- a/index.html
+++ b/index.html
@@ -159,5 +159,60 @@ ga('create', 'UA-64755004-1', 'auto');
 ga('send', 'pageview');
 }
 </script>
+
+<style>
+#deprecation-dialog-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100000;
+}
+#deprecation-dialog {
+  background: white;
+  padding: 26px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 600px;
+  width: 80%;
+}
+#deprecation-dialog h1 {
+  margin-top: 0;
+}
+
+#deprecation-dialog p {
+  font-size: 16px;
+  color: black;
+  margin: 10px 0 0 0;
+}
+
+#deprecation-dialog a {
+  margin: 10px 0 0 0;
+  display: block;
+  width: 100%;
+  text-align: center;
+  font-size: 18px;
+}
+#deprecation-dialog button {
+  color: black;
+  margin: 10px 0 0 0;
+}
+</style>
+<div id="deprecation-dialog-container">
+  <div id="deprecation-dialog">
+    <h1>New unofficial timetable available!</h1>
+    <p>
+      The ANU Computer Science Students' Association is pleased to announce a new unofficial timetable planner. It is available here:
+    </p>
+    <a href="https://timetable.cssa.club/">https://timetable.cssa.club/</a>
+    <p>It's updated for 2022 semester 1 and has lots of new features including a timezone dropdown and the ability to link to external calendars.</p>
+    <button onclick="document.getElementById('deprecation-dialog-container').style.display='none'">Close</button>
+  </div>
+</div>
+
 </body>
 </html>

--- a/semester_update/index_template.html
+++ b/semester_update/index_template.html
@@ -159,5 +159,60 @@ ga('create', 'UA-64755004-1', 'auto');
 ga('send', 'pageview');
 }
 </script>
+
+<style>
+#deprecation-dialog-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100000;
+}
+#deprecation-dialog {
+  background: white;
+  padding: 26px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 600px;
+  width: 80%;
+}
+#deprecation-dialog h1 {
+  margin-top: 0;
+}
+
+#deprecation-dialog p {
+  font-size: 16px;
+  color: black;
+  margin: 10px 0 0 0;
+}
+
+#deprecation-dialog a {
+  margin: 10px 0 0 0;
+  display: block;
+  width: 100%;
+  text-align: center;
+  font-size: 18px;
+}
+#deprecation-dialog button {
+  color: black;
+  margin: 10px 0 0 0;
+}
+</style>
+<div id="deprecation-dialog-container">
+  <div id="deprecation-dialog">
+    <h1>New unofficial timetable available!</h1>
+    <p>
+      The ANU Computer Science Students' Association is pleased to announce a new unofficial timetable planner. It is available here:
+    </p>
+    <a href="https://timetable.cssa.club/">https://timetable.cssa.club/</a>
+    <p>It's updated for 2022 semester 1 and has lots of new features including a timezone dropdown and the ability to link to external calendars.</p>
+    <button onclick="document.getElementById('deprecation-dialog-container').style.display='none'">Close</button>
+  </div>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
Here's what it looks like when I inject the HTML and CSS I've added into anutimetable.com:

![image](https://user-images.githubusercontent.com/11626018/149605675-b95385d2-f069-491d-a60b-3662d8cbb32d.png)

I assume inserting the code into both HTML files will do the trick

I've also updated the README to direct people to the new repo

@BishopOfTurkey we're still putting in the finishing touches on timetable.cssa.club so I'd appreciate it if you could review/approve these changes now, but hold off on merging them until Tom Plant and I agree it's ready
